### PR TITLE
Request scaled-down imagery from Wikimedia

### DIFF
--- a/backend/data/fetch.ts
+++ b/backend/data/fetch.ts
@@ -1,0 +1,96 @@
+import * as https from "https";
+
+export const DEFAULT_USER_AGENT = 'GetMeDrunkEfficiently/0.0 (https://github.com/Quaffel/get-me-drunk-efficiently)';
+
+export type MimeType =
+    | 'application/sparql-results+json'
+    | 'application/x-www-form-urlencoded'
+    | 'application/json';
+
+interface FetchRequestBase<T extends string, M extends MimeType> {
+    method: T;
+    accept: M;
+    userAgent?: string,
+    customHeaders?: { [headerName: string]: string }
+}
+export interface GetFetchRequest<M extends MimeType> extends FetchRequestBase<'GET', M> { }
+export interface PostFetchRequest<M extends MimeType> extends FetchRequestBase<'POST', M> {
+    body: {
+        mimeType: MimeType,
+        content: string
+    }
+}
+export type FetchRequest<M extends MimeType> = GetFetchRequest<M> | PostFetchRequest<M>;
+
+interface FetchResponseBase<T extends string> {
+    type: T;
+}
+export interface SuccessfulFetchResponse<M extends MimeType> extends FetchResponseBase<'success'> {
+    statusCode: number;
+    body: {
+        mimeType: M,
+        content: string
+    };
+}
+export interface RedirectFetchResponse extends FetchResponseBase<'redirect'> { location?: string };
+export interface ErrorFetchResponse extends FetchResponseBase<'error'> { error: any; }
+export type FetchResponse<M extends MimeType> =
+    | SuccessfulFetchResponse<M> | RedirectFetchResponse
+    | ErrorFetchResponse;
+
+export function fetch<M extends MimeType>(url: string, request: FetchRequest<M>): Promise<FetchResponse<M>> {
+    const headers: any = {
+        'Accept': request.accept,
+        'User-Agent': request.userAgent ?? DEFAULT_USER_AGENT,
+        ...request.customHeaders
+    };
+
+    if (request.method === 'POST') {
+        headers['Content-Type'] = request.body.mimeType;
+        headers['Content-Length'] = Buffer.byteLength(request.body.content);
+    }
+
+    return new Promise((resolve, _) => {
+        const httpRequest = https.request(url, {
+            method: request.method,
+            headers
+        }, async (res) => {
+            try {
+                let responseBody = "";
+
+                res.setEncoding("utf-8");
+                for await (const chunk of res) {
+                    responseBody += chunk;
+                }
+
+                if (res.statusCode === 301) {
+                    resolve({
+                        type: 'redirect',
+                        location: res.headers.location
+                    });
+                }
+
+                resolve({
+                    type: 'success',
+                    statusCode: res.statusCode!,
+                    body: {
+                        mimeType: request.accept,
+                        content: responseBody
+                    }
+                });
+            } catch (error: any) {
+                return {
+                    error
+                };
+            }
+        }).on('error', (error) => resolve({
+            type: 'error',
+            error
+        }));
+
+        if (request.method === 'POST') {
+            httpRequest.write(request.body.content);
+        }
+        httpRequest.end();
+    });
+}

--- a/backend/data/openfoodfacts.ts
+++ b/backend/data/openfoodfacts.ts
@@ -1,53 +1,51 @@
-import { cached, USER_AGENT } from "./util";
-import * as https from "https";
+import { cached } from "./util";
+import { fetch } from './fetch';
 
-export const getAlcohol = cached(function fetchAlcohol(category: string): Promise<number> {
-    return new Promise<number>((resolve, reject) => {
-        const url = `https://world.openfoodfacts.org/category/${encodeURIComponent(category)}.json?page_size=50`;
-        const requestTime = Date.now();
-        const request = https.get(url, {
-            headers: {
-                'Accept': 'application/json',
-                'User-Agent': USER_AGENT
-            }
-        }, async (res) => {
-            if(res.statusCode === 301) {
-                // Handle redirects
-                const newCategory = res.headers.location?.replace('/category/', '').replace('.json', '') as string;
+export const getAlcohol = cached(async function fetchAlcohol(category: string): Promise<number> {
+    const url = `https://world.openfoodfacts.org/category/${encodeURIComponent(category)}.json?page_size=50`;
 
-                console.log(`OpenFoodFacts redirected ${category} -> ${newCategory}`);
-                return resolve(await fetchAlcohol(newCategory));
-            }
-            let body: string = '';
-            res.on('error', (err) => reject(err));
-            res.on('data', (chunk: string) => body += chunk);
-            res.on('end', () => {
-                // Debug
-                const returnTime = Date.now();
-
-                const avgAlcohol = Math.round(parseOffResult(body) * 10) / 10;
-                resolve(avgAlcohol);
-                console.log(`OpenFoodFacts query for '${category}' (avg. ${avgAlcohol} %vol) ended after ${returnTime - requestTime}ms`);
-            });
-        });
+    const requestTime = Date.now();
+    const response = await fetch<'application/json'>(url, {
+        method: 'GET',
+        accept: 'application/json'
     });
+    const returnTime = Date.now();
+
+    if (response.type === 'error') {
+        throw new Error(response.error);
+    }
+
+    if (response.type === 'redirect') {
+        const newCategory = response.location!.replace('/category/', '').replace('.json', '');
+        console.log(`OpenFoodFacts redirected ${category} -> ${newCategory}`);
+
+        return await fetchAlcohol(newCategory);
+    }
+
+    const averageAlcohol = parseOffResult(response.body.content);
+
+    // Ensure accuracy of a single decimal
+    const roundedAverageAlcohol = Math.round(averageAlcohol * 10) / 10;
+
+    console.log(`OpenFoodFacts query for '${category}' (avg. ${roundedAverageAlcohol} %vol) ended after ${returnTime - requestTime}ms`);
+    return roundedAverageAlcohol;
 });
 
-interface OffResult {
+interface FoodFactsResult {
     count: number;
-    products: {
+    products: Array<{
         no_nutrition_data: '' | 'on',
         nutriments: {
             alcohol?: number;
         }
-    }[]
+    }>;
 }
 
 function parseOffResult(result: string): number {
-    const { products, count } = (JSON.parse(result) as OffResult);
+    const { products, count } = (JSON.parse(result) as FoodFactsResult);
 
     // For global categories such as "beverages", building an average value is useless
-    if(count > 1000)
+    if (count > 1000)
         return 0;
 
     // Get all alcohol values from products
@@ -55,10 +53,10 @@ function parseOffResult(result: string): number {
         .filter(el => el.no_nutrition_data === '')
         .map(product => product.nutriments.alcohol)
         .filter(val => val) as number[];
-        
-    if(productsAlcohol.length === 0)
+
+    if (productsAlcohol.length === 0)
         return 0;
-        
+
     // Return average
     return productsAlcohol.reduce((sum, current) => sum + (+current || 0), 0) / productsAlcohol.length;
 }

--- a/backend/data/util.ts
+++ b/backend/data/util.ts
@@ -1,5 +1,3 @@
-export const USER_AGENT = 'GetMeDrunkEfficiently/0.0 (https://github.com/Quaffel/get-me-drunk-efficiently)';
-
 export function normalize(ingredientAmount: number, unit: string): { val: number, unit: string } {
     // Convert every known unit to ml
     switch(unit) {
@@ -45,4 +43,42 @@ export function once<T>(retrieve: () => T) {
         
         return cached;
     }
+}
+
+export type NonEmptyArray<T> = [T, ...T[]];
+
+export type DeepPartial<T> = T extends object ? {
+    [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+export type DeepNonNullable<T> = T extends object ? {
+    [K in keyof T]-?: DeepNonNullable<T[K]>;  
+} : NonNullable<T>;
+
+export function isDeepNonNullable<T extends { [name: PropertyKey]: any }>(obj: T): obj is DeepNonNullable<T> {
+    for (let entry of Object.entries(obj)) {
+        const value = entry[1];
+        if (value === null || value === undefined) {
+            return false;
+        }
+        if (typeof value === 'object' && !isDeepNonNullable(value)) {
+            return false;
+        } 
+    }
+
+    return true;
+}
+
+export function discerpInBatches<T>(data: Array<T>, maxBatchSize: number): Array<NonEmptyArray<T>> {
+    let result: Array<NonEmptyArray<T>> = [];
+    let batchStartIndex = 0;
+    while (batchStartIndex < data.length) {
+        const batchSize = Math.min(data.length - batchStartIndex, maxBatchSize);
+        const batchEndIndex = batchStartIndex + batchSize;
+
+        result.push(data.slice(batchStartIndex, batchEndIndex) as NonEmptyArray<T>);
+        batchStartIndex = batchEndIndex;
+    }
+
+    return result;
 }

--- a/backend/data/wikidata.ts
+++ b/backend/data/wikidata.ts
@@ -189,7 +189,6 @@ async function fetchDrinkData(): Promise<WikidataCocktail[]> {
     }
 
     const parsedResponse: any = JSON.parse(result.body.content);
-    console.log(result.body.content);
     return parsedResponse.results.bindings;
 }
 
@@ -209,7 +208,6 @@ function toDrinksAndIngredients(cocktails: WikidataCocktail[]): { drinks: IDrink
             let drink = drinks.get(cocktail.value);
 
             if(!drink) {
-                console.log(imageUrl?.value);
                 drink = {
                     name: cocktailLabel.value,
                     image: imageUrl?.value,
@@ -281,10 +279,8 @@ const getDrinksAndIngredients = once(async () => {
     const result = await fetchDrinkData();
     const { drinks, ingredients } = toDrinksAndIngredients(result);
 
-    const oldDrinkUrls = drinks.map(it => it.image);
-
     // then fetch additional alcohol data from OpenFoodFacts
-    // await Promise.all(ingredients.map(enrichAlcohol));
+    await Promise.all(ingredients.map(enrichAlcohol));
     
     // as all data is now present, accumulate totals
     drinks.forEach(accumulateTotal);
@@ -310,8 +306,6 @@ const getDrinksAndIngredients = once(async () => {
 
         drink.image = imageInfo.scaledImage.url;
     }
-
-    console.log(oldDrinkUrls);
 
     return { drinks, ingredients };
 });

--- a/backend/data/wikimedia-imageinfo.ts
+++ b/backend/data/wikimedia-imageinfo.ts
@@ -1,0 +1,193 @@
+// Documentation for the Wikimedia Imageinfo API is available under
+// https://www.mediawiki.org/wiki/API:Imageinfo
+
+import { IDrink } from "../../types";
+import { fetch } from "./fetch";
+import { DeepPartial, discerpInBatches, isDeepNonNullable, NonEmptyArray } from "./util";
+
+export interface ImageMetadata {
+    width: number;
+    height: number;
+    url: string;
+}
+export interface ImageInfo {
+    originalImage: ImageMetadata & { sizeInBytes: number; };
+    scaledImage: ImageMetadata;
+    mimeType: string;
+}
+
+interface WikimediaRootInfo {
+    batchcomplete: string,
+    query: WikimediaQueryInfo
+}
+interface WikimediaQueryInfo {
+    normalized: any;
+    pages: {
+        [index: number]: WikimediaPageInfo
+    };
+}
+interface WikimediaPageInfo {
+    imageinfo: {
+        [index: number]: WikimediaImageInfo
+    };
+}
+interface WikimediaImageInfo {
+    size: number;
+    width: number;
+    height: number;
+    thumburl: string;
+    thumbwidth: number;
+    thumbheight: number;
+    responsiveUrls: {
+        2: string;
+        1.5: string;
+    };
+    url: string;
+    mime: string;
+    descriptionurl: string;
+}
+
+export async function fetchScalingImageInfo<D extends Array<IDrink>>(
+    drinks: D,
+    maxDimensions: {
+        width: number,
+        height: number
+    }
+): Promise<{
+    [K in typeof drinks[number]['name']]: ImageInfo
+} | null> {
+    type DrinkInfoMapping = { [K in typeof drinks[number]['name']]: ImageInfo };
+
+    const drinksWithImages = drinks.filter(it => !!it);
+
+    const fetchTasks: Array<Promise<DrinkInfoMapping>> = [];
+    for (let batch of discerpInBatches(drinksWithImages, 50)) {
+        console.log(batch.map(it => it.name));
+        fetchTasks.push(fetchScalingImageInfo0(batch, maxDimensions) as Promise<DrinkInfoMapping>);
+    }
+
+    const infoMappings = await Promise.all(fetchTasks);
+    return infoMappings.reduce((acc, mapping) => Object.assign(acc, mapping), {} as any);
+}
+
+async function fetchScalingImageInfo0<D extends NonEmptyArray<IDrink>>(
+    drinks: D,
+    maxDimensions: {
+        width: number,
+        height: number
+    }
+): Promise<{
+    [K in typeof drinks[number]['name']]: ImageInfo
+} | null> {
+
+    // const imageMapping: Map<string, typeof drinks[number]> = new Map();
+
+    let url = new URL("https://www.wikidata.org/w/api.php");
+    url.searchParams.append("action", "query");
+    url.searchParams.append("format", "json");
+    url.searchParams.append("prop", "imageinfo");
+    url.searchParams.append("iiprop", "url|mime|size");
+    url.searchParams.append("iiurlwidth", maxDimensions.width.toFixed(0));
+    url.searchParams.append("iiurlheight", maxDimensions.height.toFixed(0));
+
+    // Bar-separated list of all Wikimedia image files
+    // e.g.: File:Martini.jpg|File:Vodka.jpg
+    // Wikimedia image URLs are provided in the URL scheme https://commons.wikimedia.org/wiki/<ref>
+    const drinksParamValue = (drinks
+        .map(it => {
+            const imageUrl = new URL(it.image!);
+            const matchInfo = imageUrl.pathname.match(/\/wiki\/(File:.+\.\w{1,3})/);
+
+            if (matchInfo === null) {
+                console.log("Warning: in imageinfo: Image URL does not match the expected pattern", it.image!);
+                return null;
+            }
+
+            return decodeURIComponent(matchInfo[1]);
+        })
+        .filter(it => it !== null) as Array<string>)
+        .reduce(
+            (acc, imageUrl) => `${acc}|${imageUrl}`,
+            ""
+        ).slice(1);
+    url.searchParams.append("titles", drinksParamValue);
+
+    console.log("Fetching data from: ", url.toString());
+    const result = await fetch<'application/json'>(url.toString(), {
+        method: 'GET',
+        accept: 'application/json'
+    });
+
+    if (result.type === 'redirect') {
+        throw new Error("Unexpected redirect");
+    }
+    if (result.type === 'error') {
+        throw new Error(result.error);
+    }
+
+    const parsedResult = JSON.parse(result.body.content) as Partial<WikimediaRootInfo>;
+    const pages = parsedResult?.query?.pages;
+
+    if (!pages) {
+        throw new Error("Unexpected result: " + result.body.content);
+    }
+
+    if (Object.entries(pages).length !== drinks.filter(it => !!it.image).length) {
+        console.log("Warning: Length mismatch", Object.entries(pages).length, drinks.filter(it => !!it.image).length);
+    }
+
+    let res: { [K in typeof drinks[number]['name']]: ImageInfo } = {} as any;
+    for (let it of Object.values(pages)) {
+        const page = it as Partial<WikimediaPageInfo>;
+        const imageInfo = page?.imageinfo?.[0];
+
+        if (!imageInfo) {
+            throw new Error("invalid image info entry");
+        }
+
+        const descriptionUrl = new URL(imageInfo.descriptionurl);
+        const matchInfo = descriptionUrl.pathname.match(/\/wiki\/File:(.+\.\w{1,3})/);
+
+        if (matchInfo === null) {
+            console.log("Warning: Image URL does not match the expected pattern", descriptionUrl);
+            return null;
+        }
+
+        const decodedDescriptionUrl = "https://commons.wikimedia.org/wiki/File:" + decodeURIComponent(matchInfo[1]);
+
+        const drink = drinks.find(it => it.image === decodedDescriptionUrl) as typeof drinks[number] | undefined;
+        if (!drink) {
+            console.error("Couldn't map image url " + decodedDescriptionUrl + " to drink");
+            continue;
+        }
+
+        const assembledImageInfo: DeepPartial<ImageInfo> = {
+            mimeType: imageInfo?.mime,
+            originalImage: {
+                url: imageInfo?.descriptionurl,
+                height: imageInfo?.height,
+                width: imageInfo?.width,
+                sizeInBytes: imageInfo?.size
+            },
+            scaledImage: {
+                url: imageInfo?.thumburl,
+                height: imageInfo?.thumbheight,
+                width: imageInfo?.thumbwidth
+            }
+        };
+
+        if (!isDeepNonNullable(assembledImageInfo)) {
+            console.error("Image information is incomplete");
+            continue;
+        }
+
+        res[drink.name as typeof drinks[number]['name']] = assembledImageInfo;
+    }
+
+    return res;
+}
+
+
+
+// https://www.wikidata.org/w/api.php?action=query&format=json&prop=imageinfo&titles=File%3ATschunk_cropped.jpg|File:7_and_7,_Macaroni_Grill,_Dunwoody_GA.jpg&iiprop=url|mime|size&iiurlwidth=300&iiurlheight=300
+

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */

--- a/frontend/src/drinks/DrinkCard.tsx
+++ b/frontend/src/drinks/DrinkCard.tsx
@@ -2,9 +2,12 @@ import * as React from "react";
 import  { IDrink } from "../../../types";
 import { Card } from "../basic/Card";
 
+const FALLBACK_DRINK_THUMBNAIL = 
+    "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Flaming_cocktails.jpg/300px-Flaming_cocktails.jpg";
+
 export function DrinkCard({ drink }: { drink: IDrink }) {
     return <Card>
-        <Card.Image src={drink.image ?? "https://upload.wikimedia.org/wikipedia/commons/e/e7/Flaming_cocktails.jpg"} />
+        <Card.Image src={drink.image ?? FALLBACK_DRINK_THUMBNAIL} />
         <Card.Title name={drink.name} />
         <Card.Content title="Ingredients">
             {drink.ingredients.map(({ ingredient, amount, unit }) => 


### PR DESCRIPTION
With this patch, fetching the imagery of all available cocktails cause less than one megabyte to be transferred. This improves load times and overall page performance considerably. 

Since downscaling is performed by Wikimedia and can be requested in batches of up to 50 images/request, the additional startup time and additional load on our end is insignificant.

An exhaustive overview on the overall problem statement, considered alternatives, and information on the used API is provided in the issue.

Resolves #54. Preparatory change for #24.