### PR TITLE
Render and display units in a more natural way

### DIFF
--- a/backend/api/api.ts
+++ b/backend/api/api.ts
@@ -30,7 +30,7 @@ router.post('/drinks', express.json(), async (req: Request, res: Response) => {
     let eligibleDrinks;
     try {
         eligibleDrinks = await searchDrinks({
-            cocktailName: query.drinkName && query.drinkName.length > 0 ? query.drinkName : undefined,
+            drinkName: query.drinkName && query.drinkName.length > 0 ? query.drinkName : undefined,
             maxAlcoholConcentration: query.maxAlcoholConcentration,
             ingredients: query.ingredients && query.ingredients.length > 0 ? query.ingredients : undefined
         });

--- a/backend/data/util.ts
+++ b/backend/data/util.ts
@@ -1,73 +1,25 @@
-export type NormalizedUnit = 'ml' | 'whole'; 
+import { isVolumetricUnit, Unit } from "../../types";
 
-interface UnitInformation {
-    // Unit can be measured and is meaningful (i.e., significant for the alcohol concentration calculation) to measure.
-    // Positive examples: 'ml', 'tablespoon'
-    // Negative examples: '1' (not measurable), 'drop' (even though it is measurable, it is insignificant)
-    volumetric: boolean,
 
-    // Meaning of unit is well-known and can thus be displayed directly to the user.
-    // Positive examples: 'ml', 'tablespoon'
-    // Negative example: 'fluid ounce' (not contemporary)
-    trivial: boolean
-}
-
-type FilterUnits<P extends Partial<UnitInformation>> = keyof {
-    [K in keyof typeof UNITS as typeof UNITS[K] extends P ? K : never]: never
-}
-
-export type Unit = keyof typeof UNITS;
-export function isUnit(str: string): str is Unit {
-    return str in UNITS;
-}
-
-export type VolumetricUnit = FilterUnits<{ volumetric: true }>;
-export function isVolumetricUnit(unit: Unit): unit is VolumetricUnit {
-    return UNITS[unit].volumetric;
-}
-
-export type TrivialUnit = FilterUnits<{ trivial: true }>;
-export function isTrivialUnit(unit: Unit): unit is TrivialUnit {
-    return UNITS[unit].trivial;
-}
-
-const UNITS = {
-    '1':                    { volumetric: false,    trivial: true   },
-    'ml':                   { volumetric: true,     trivial: true   },
-    'ounce':                { volumetric: true,     trivial: true   },
-    'fluid ounce':          { volumetric: true,     trivial: true   },
-    'centilitre':           { volumetric: true,     trivial: true   },
-    'millilitre':           { volumetric: true,     trivial: true   },
-    'splash':               { volumetric: true,     trivial: true   },
-    'dash':                 { volumetric: true,     trivial: true   },
-    'teaspoon':             { volumetric: true,     trivial: true   },
-    'teaspoon (metric)':    { volumetric: true,     trivial: true   },
-    'bar spoon':            { volumetric: true,     trivial: true   },
-    'tablespoon':           { volumetric: true,     trivial: true   },
-    'Stemware':             { volumetric: true,     trivial: true   },
-    'drop':                 { volumetric: false,    trivial: false  },
-    'pinch':                { volumetric: false,    trivial: false  }
-} as const;
-
-export function normalize(ingredientAmount: number, unit: Unit): { val: number, unit: NormalizedUnit } {
+export function normalize(ingredientAmount: number, unit: Unit): number {
     if (!isVolumetricUnit(unit)) {
-        return { val: 0, unit: 'ml' };
+        return 0;
     }
 
     // Convert every known unit to ml
     switch(unit) {
-        case 'ml':                return { val: ingredientAmount,           unit: 'ml'    };
-        case 'ounce':             return { val: ingredientAmount * 29.5735, unit: 'ml'    };
-        case 'fluid ounce':       return { val: ingredientAmount * 29.5735, unit: 'ml'    };
-        case 'centilitre':        return { val: ingredientAmount * 10,      unit: 'ml'    };
-        case 'millilitre':        return { val: ingredientAmount,           unit: 'ml'    };
-        case 'splash':            return { val: ingredientAmount * 3.7,     unit: 'ml'    };
-        case 'dash':              return { val: ingredientAmount * 0.9,     unit: 'ml'    };
-        case 'teaspoon':          return { val: ingredientAmount * 3.7,     unit: 'ml'    };
-        case 'teaspoon (metric)': return { val: ingredientAmount * 3.7,     unit: 'ml'    };
-        case 'bar spoon':         return { val: ingredientAmount * 2.5,     unit: 'ml'    };
-        case 'tablespoon':        return { val: ingredientAmount * 11.1,    unit: 'ml'    };
-        case 'Stemware':          return { val: ingredientAmount * 150,     unit: 'ml'    };
+        case 'ml':                return ingredientAmount;
+        case 'ounce':             return ingredientAmount * 29.5735;
+        case 'fluid ounce':       return ingredientAmount * 29.5735;
+        case 'centilitre':        return ingredientAmount * 10;
+        case 'millilitre':        return ingredientAmount;
+        case 'splash':            return ingredientAmount * 3.7;
+        case 'dash':              return ingredientAmount * 0.9;
+        case 'teaspoon':          return ingredientAmount * 3.7;
+        case 'teaspoon (metric)': return ingredientAmount * 3.7;
+        case 'bar spoon':         return ingredientAmount * 2.5;
+        case 'tablespoon':        return ingredientAmount * 11.1;
+        case 'Stemware':          return ingredientAmount * 150;
     }
 }
 

--- a/backend/services.ts
+++ b/backend/services.ts
@@ -35,8 +35,6 @@ export async function searchDrinks({
         }   
     }
 
-    console.log("after alc concentration: " + drinks.find(it => it.name === "Ramos Gin Fizz"));
-
     return drinks;
 }
 

--- a/backend/services.ts
+++ b/backend/services.ts
@@ -1,6 +1,5 @@
-import { IDrink, IDrinkAmount, IIngredient, IIngredientAmount } from '../types';
+import { IDrink, IDrinkAmount, IIngredient } from '../types';
 import { getDrinks, getIngredients } from './data/';
-import { normalize } from './data/util';
 
 const ALCOHOL_GRAM_TO_ML = 16 / 10;
 
@@ -9,18 +8,18 @@ export async function getAllIngredients(): Promise<IIngredient[]> {
 }
 
 export async function searchDrinks({
-    cocktailName,
+    drinkName,
     maxAlcoholConcentration,
     ingredients
 }: {
-    cocktailName?: string,
+    drinkName?: string,
     maxAlcoholConcentration?: number,
     ingredients?: Array<IIngredient["name"]>
 }): Promise<IDrink[]> {
     let drinks = await getDrinks();
 
-    if (cocktailName) {
-        drinks = drinks.filter(it => it.name.toLowerCase().includes(cocktailName.toLowerCase()));
+    if (drinkName) {
+        drinks = drinks.filter(it => it.name.toLowerCase().includes(drinkName.toLowerCase()));
     }
 
     if (ingredients) {
@@ -33,10 +32,10 @@ export async function searchDrinks({
     if (maxAlcoholConcentration !== undefined) {
         if (maxAlcoholConcentration < 0 || maxAlcoholConcentration > 1) {
             throw new Error("Alcohol concentration is out of bounds");
-        }
-
-        drinks = drinks.filter(it => (it.alcoholVolume / calculateTotalVolume(it)) <= maxAlcoholConcentration);
+        }   
     }
+
+    console.log("after alc concentration: " + drinks.find(it => it.name === "Ramos Gin Fizz"));
 
     return drinks;
 }

--- a/types.ts
+++ b/types.ts
@@ -7,7 +7,7 @@ export interface IIngredient {
 export interface IIngredientAmount {
     ingredient: IIngredient;
     amount: number;
-    unit: string;
+    unit: Unit;
 }
 
 export interface IDrink {
@@ -23,3 +23,54 @@ export interface IDrinkAmount {
     drink: IDrink;
     amount: number;
 }
+
+// Unit system
+
+interface UnitInformation {
+    // Unit can be measured and is meaningful (i.e., significant for the alcohol concentration calculation) to measure.
+    // Positive examples: 'ml', 'tablespoon'
+    // Negative examples: '1' (not measurable), 'drop' (even though it is measurable, it is insignificant)
+    volumetric: boolean,
+
+    // Meaning of unit is well-known and can thus be displayed directly to the user.
+    // Positive examples: 'ml', 'tablespoon'
+    // Negative example: 'fluid ounce' (not contemporary)
+    trivial: boolean
+}
+
+type FilterUnits<P extends Partial<UnitInformation>> = keyof {
+    [K in keyof typeof UNITS as typeof UNITS[K] extends P ? K : never]: never
+}
+
+export type Unit = keyof typeof UNITS;
+export function isUnit(str: string): str is Unit {
+    return str in UNITS;
+}
+
+export type VolumetricUnit = FilterUnits<{ volumetric: true }>;
+export function isVolumetricUnit(unit: Unit): unit is VolumetricUnit {
+    return UNITS[unit].volumetric;
+}
+
+export type TrivialUnit = FilterUnits<{ trivial: true }>;
+export function isTrivialUnit(unit: Unit): unit is TrivialUnit {
+    return UNITS[unit].trivial;
+}
+
+const UNITS = {
+    '1':                    { volumetric: false,    trivial: true   },
+    'ml':                   { volumetric: true,     trivial: true   },
+    'ounce':                { volumetric: true,     trivial: true   },
+    'fluid ounce':          { volumetric: true,     trivial: true   },
+    'centilitre':           { volumetric: true,     trivial: true   },
+    'millilitre':           { volumetric: true,     trivial: true   },
+    'splash':               { volumetric: true,     trivial: true   },
+    'dash':                 { volumetric: true,     trivial: true   },
+    'teaspoon':             { volumetric: true,     trivial: true   },
+    'teaspoon (metric)':    { volumetric: true,     trivial: true   },
+    'bar spoon':            { volumetric: true,     trivial: true   },
+    'tablespoon':           { volumetric: true,     trivial: true   },
+    'Stemware':             { volumetric: true,     trivial: true   },
+    'drop':                 { volumetric: false,    trivial: true   },
+    'pinch':                { volumetric: false,    trivial: false  }
+} as const;


### PR DESCRIPTION
Introduces the notion of "volumetric" (i.e., sensible to be measured in volume units) and "trivial" (i.e., understandable without any further conversions, from a Western standpoint of view) units. Resolves #41.

Furthermore fixes duplicate appearances of single ingredients (since they appear multiple times in the query's result set. This may happen when an ingredient is assigned to multiple categories). Resolves #51.